### PR TITLE
Update ticket search service query and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ urlFragment: microsoft-teams-apps-remotesupport
 | [Documentation](https://github.com/OfficeDev/microsoft-teams-apps-remotesupport/wiki/Home) | [Deployment guide](https://github.com/OfficeDev/microsoft-teams-apps-remotesupport/wiki/Deployment-Guide) | [Architecture](https://github.com/OfficeDev/microsoft-teams-apps-remotesupport/wiki/Solution-Overview) |
 | ---- | ---- | ---- |
 
+## Remote Support bot
+
 Most organizations have a team of remote individuals providing support to employees across the organization often distributed geographically. Support and collaboration in such instances is often ad-hoc, sub-optimal and inefficient. Common incumbent solutions include shared email-inbox where employees send in requests; a SharePoint site where requests are submitted; calling a dedicated helpline,  email or chat based messaging systems with a dedicated point person etc.
  
-Remote Support Bot provides all end users (internal users seeking help from a central team) an easy interface (bot) right within Microsoft Teams to:
+Remote Support bot provides all end users (internal users seeking help from a central team) an easy interface (bot) right within Microsoft Teams to:
 
 - Submit requests for support
 - Edit/withdraw requests

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Remote Support bot provides all end users (internal users seeking help from a ce
 
 ![Remote support new request](https://github.com/OfficeDev/microsoft-teams-apps-remotesupport/wiki/Images/new-request.png)
 
-![Remote support messaging extension](https://github.com/OfficeDev/microsoft-teams-apps-remotesupport/wiki/Images/messaging-extension.png)
+![Remote support messaging extension](https://github.com/OfficeDev/microsoft-teams-apps-remotesupport/wiki/Images/support-team-ackcard.jpg)
 
 ## Legal Notice
 Please read the license terms applicable to this app template [here](https://github.com/OfficeDev/microsoft-teams-apps-remotesupport/blob/master/LICENSE). In addition to these terms, by using this app template you agree to the following:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ urlFragment: microsoft-teams-apps-remotesupport
 | [Documentation](https://github.com/OfficeDev/microsoft-teams-apps-remotesupport/wiki/Home) | [Deployment guide](https://github.com/OfficeDev/microsoft-teams-apps-remotesupport/wiki/Deployment-Guide) | [Architecture](https://github.com/OfficeDev/microsoft-teams-apps-remotesupport/wiki/Solution-Overview) |
 | ---- | ---- | ---- |
 
-## Remote Support bot
+# Remote Support App Template
 
 Most organizations have a team of remote individuals providing support to employees across the organization often distributed geographically. Support and collaboration in such instances is often ad-hoc, sub-optimal and inefficient. Common incumbent solutions include shared email-inbox where employees send in requests; a SharePoint site where requests are submitted; calling a dedicated helpline,  email or chat based messaging systems with a dedicated point person etc.
  

--- a/Source/Microsoft.Teams.Apps.RemoteSupport.Common/Providers/TicketSearchService.cs
+++ b/Source/Microsoft.Teams.Apps.RemoteSupport.Common/Providers/TicketSearchService.cs
@@ -98,12 +98,12 @@ namespace Microsoft.Teams.Apps.RemoteSupport.Common.Providers
                     break;
 
                 case TicketSearchScope.AssignedTickets:
-                    searchParameters.Filter = $"TicketStatus eq {(int)TicketState.Assigned} and AssignedToName ne null";
+                    searchParameters.Filter = $"TicketStatus eq {(int)TicketState.Assigned}";
                     searchParameters.OrderBy = new[] { "Timestamp desc" };
                     break;
 
                 case TicketSearchScope.UnassignedTickets:
-                    searchParameters.Filter = $"TicketStatus eq {(int)TicketState.Unassigned} and AssignedToName eq null";
+                    searchParameters.Filter = $"TicketStatus eq {(int)TicketState.Unassigned}";
                     searchParameters.OrderBy = new[] { "Timestamp desc" };
                     break;
                 case TicketSearchScope.ActiveTickets:

--- a/Source/Microsoft.Teams.Apps.RemoteSupport.Configuration/ClientApp/src/components/input-text-form.tsx
+++ b/Source/Microsoft.Teams.Apps.RemoteSupport.Configuration/ClientApp/src/components/input-text-form.tsx
@@ -31,7 +31,7 @@ const InputTextForm: React.FunctionComponent<IPropertiesProps> = (props) => {
                     <Input fluid placeholder={props.resourceStrings.placeholderText} value={properties.placeholder} onChange={(e: any) => { setProperties({ ...properties, placeholder: e.target.value }) }} />
                 </>
             </Flex.Item>
-            <Button content={props.resourceStrings.common.btnAddComponent} onClick={onAddComponent} />
+            <Button content={props.resourceStrings.btnAddComponent} onClick={onAddComponent} />
         </>
     );
 }


### PR DESCRIPTION
- [Fix]: Assigned and unassigned ticket requests uses ticket status and assigned to name search parameters. However, assigned to name is not a required field in search criteria. Due to this the recently created tickets do not show up as unassigned, and shows only when a ticket is assigned > unassigned by support team.
- [Fix]: ReadMe file to use new images and added missing app title
- [Fix]: Input text form in configuration app service to use correct resource property name for button text.